### PR TITLE
Test code fix to work with serenity 1.1.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ repositories {
 }
 
 ext{
-    serenity_version = "1.1.22-rc.11"
-    serenity_jbehave_version = "1.5.0"
-    serenity_cucumber_version = "1.1.2"
+    serenity_version = "1.1.25"
+    serenity_jbehave_version = "1.6.0"
+    serenity_cucumber_version = "1.1.5"
 }
 
 buildscript {
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("net.serenity-bdd:serenity-gradle-plugin:1.1.22-rc.11")
+        classpath("net.serenity-bdd:serenity-gradle-plugin:1.1.25")
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.1.25-rc.5</serenity.version>
-        <serenity.maven.version>1.1.25-rc.5</serenity.maven.version>
-        <serenity.cucumber.version>1.1.2</serenity.cucumber.version>
-        <serenity.jbehave.version>1.1.0</serenity.jbehave.version>
+        <serenity.version>1.1.25</serenity.version>
+        <serenity.maven.version>1.1.25</serenity.maven.version>
+        <serenity.cucumber.version>1.1.5</serenity.cucumber.version>
+        <serenity.jbehave.version>1.6.0</serenity.jbehave.version>
         <!--  <webdriver.driver>firefox</webdriver.driver> -->
         <!--  <parallel.tests>1</parallel.tests> -->
     </properties>

--- a/src/main/java/net/serenitybdd/demos/todos/tasks/AddATodoItem.java
+++ b/src/main/java/net/serenitybdd/demos/todos/tasks/AddATodoItem.java
@@ -3,8 +3,8 @@ package net.serenitybdd.demos.todos.tasks;
 import net.serenitybdd.demos.todos.pages.components.ToDoList;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Performable;
-import net.serenitybdd.screenplay.tasks.Enter;
-import net.serenitybdd.screenplay.tasks.Hit;
+import net.serenitybdd.screenplay.actions.Enter;
+import net.serenitybdd.screenplay.actions.Hit;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;

--- a/src/main/java/net/serenitybdd/demos/todos/tasks/AddItems.java
+++ b/src/main/java/net/serenitybdd/demos/todos/tasks/AddItems.java
@@ -5,7 +5,7 @@ import net.serenitybdd.core.exceptions.TestCompromisedException;
 import net.serenitybdd.demos.todos.pages.ApplicationHomePage;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Performable;
-import net.serenitybdd.screenplay.tasks.Open;
+import net.serenitybdd.screenplay.actions.Open;
 import net.thucydides.core.annotations.Pending;
 import net.thucydides.core.annotations.Step;
 import org.openqa.selenium.ElementNotVisibleException;

--- a/src/main/java/net/serenitybdd/demos/todos/tasks/ClearCompletedItems.java
+++ b/src/main/java/net/serenitybdd/demos/todos/tasks/ClearCompletedItems.java
@@ -3,7 +3,7 @@ package net.serenitybdd.demos.todos.tasks;
 import net.serenitybdd.demos.todos.pages.components.FilterBar;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Performable;
-import net.serenitybdd.screenplay.tasks.Click;
+import net.serenitybdd.screenplay.actions.Click;
 import net.thucydides.core.annotations.Pending;
 import net.thucydides.core.annotations.Step;
 

--- a/src/main/java/net/serenitybdd/demos/todos/tasks/CompleteItem.java
+++ b/src/main/java/net/serenitybdd/demos/todos/tasks/CompleteItem.java
@@ -3,7 +3,7 @@ package net.serenitybdd.demos.todos.tasks;
 import net.serenitybdd.demos.todos.pages.components.ToDoList;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Performable;
-import net.serenitybdd.screenplay.tasks.Click;
+import net.serenitybdd.screenplay.actions.Click;
 import net.thucydides.core.annotations.Pending;
 import net.thucydides.core.annotations.Step;
 

--- a/src/main/java/net/serenitybdd/demos/todos/tasks/FilterItems.java
+++ b/src/main/java/net/serenitybdd/demos/todos/tasks/FilterItems.java
@@ -4,7 +4,7 @@ import net.serenitybdd.demos.todos.model.TodoStatusFilter;
 import net.serenitybdd.demos.todos.pages.components.FilterBar;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Performable;
-import net.serenitybdd.screenplay.tasks.Click;
+import net.serenitybdd.screenplay.actions.Click;
 import net.thucydides.core.annotations.Step;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;


### PR DESCRIPTION
#### Summary of this PR

Updating of test to work with serenity core 1.1.25 also updating dependency (serenity-jbehave and serenty-cucumber) to last published 
#### Intended effect

Tests should execute without any nullpointers
#### How should this be manually tested?

`mvn clean verify`
or 
`gradle clean test aggregate`
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

serenity-bdd/serenity-core/issues/286
#### Screenshots (if appropriate)

![screenshot from 2016-02-06 14-34-43](https://cloud.githubusercontent.com/assets/1667699/12866662/da4fcd20-ccde-11e5-9e0e-946c7ef65db0.png)
